### PR TITLE
Various cross-platform fixes, enable DynamicType parent, pending jobs improvements

### DIFF
--- a/Packages/cc.starlessnight.unity-jsb/Plugins/WSA/ARM/quickjs.dll.meta
+++ b/Packages/cc.starlessnight.unity-jsb/Plugins/WSA/ARM/quickjs.dll.meta
@@ -12,16 +12,69 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude WindowsStoreApps: 0
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
       enabled: 0
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings:
+        CPU: ARM
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Packages/cc.starlessnight.unity-jsb/Plugins/WSA/ARM64/quickjs.dll.meta
+++ b/Packages/cc.starlessnight.unity-jsb/Plugins/WSA/ARM64/quickjs.dll.meta
@@ -12,16 +12,69 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude WindowsStoreApps: 0
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
       enabled: 0
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings:
+        CPU: ARM64
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Packages/cc.starlessnight.unity-jsb/Plugins/WSA/x64/quickjs.dll.meta
+++ b/Packages/cc.starlessnight.unity-jsb/Plugins/WSA/x64/quickjs.dll.meta
@@ -12,16 +12,69 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude WindowsStoreApps: 0
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
       enabled: 0
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings:
+        CPU: X64
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Packages/cc.starlessnight.unity-jsb/Plugins/WSA/x86/quickjs.dll.meta
+++ b/Packages/cc.starlessnight.unity-jsb/Plugins/WSA/x86/quickjs.dll.meta
@@ -12,16 +12,69 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude WindowsStoreApps: 0
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
       enabled: 0
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings:
+        CPU: X86
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Packages/cc.starlessnight.unity-jsb/Plugins/WebGL/libquickjs.c.meta
+++ b/Packages/cc.starlessnight.unity-jsb/Plugins/WebGL/libquickjs.c.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:
@@ -68,7 +68,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: LinuxUniversal
     second:

--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/DynamicType.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/DynamicType.cs
@@ -21,20 +21,19 @@ namespace QuickJS.Binding
         public string name => _type.Name;
 
         public Type type => _type; 
-
-        // public DynamicType _parentType { get; }
+        public DynamicType _parentType { get; }
 
         public bool privateAccess
         {
             get { return _privateAccess; }
         }
 
-        public DynamicType(Type type, bool privateAccess/*, DynamicType parentType*/)
+        public DynamicType(Type type, bool privateAccess, DynamicType parentType)
         {
             _type = type;
             _type_id = -1;
             _privateAccess = privateAccess;
-            // _parentType = parentType;
+            _parentType = parentType;
         }
 
         public void OpenPrivateAccess()
@@ -215,16 +214,18 @@ namespace QuickJS.Binding
             }
             #endregion
 
-            // if (_parentType != null)
-            // {
-            //     var ctor = cls.GetConstructor();
-            //     var parentCtor = db.GetConstructorOf(_parentType.type);
-            //     JSApi.JS_SetPrototype(ctx, ctor, parentCtor);
+            if (_parentType != null)
+            {
+                var ctor = cls.GetConstructor();
+                var parentCtor = db.GetConstructorOf(_parentType.type);
+                JSApi.JS_SetPrototype(ctx, ctor, parentCtor);
+                JSApi.JS_FreeValue(ctx, ctor);
+                JSApi.JS_FreeValue(ctx, parentCtor);
 
-            //     var prot = db.GetPrototypeOf(type);
-            //     var parentProto = db.GetPrototypeOf(_parentType.type);
-            //     JSApi.JS_SetPrototype(ctx, prot, parentProto);
-            // }
+                var prot = db.GetPrototypeOf(type);
+                var parentProto = db.GetPrototypeOf(_parentType.type);
+                JSApi.JS_SetPrototype(ctx, prot, parentProto);
+            }
 
             return cls;
         }

--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/Codegen/CodeGenUtils.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/Codegen/CodeGenUtils.cs
@@ -31,7 +31,7 @@ namespace QuickJS.Binding
         /// </summary>
         public static Assembly Compile(string source, IEnumerable<Assembly> referencedAssemblies, string compilerOptions, IBindingLogger logger)
         {
-#if !NETCOREAPP
+#if !(NETCOREAPP || NET_STANDARD_2_0 || NET_STANDARD_2_1 || NET_STANDARD)
             using (var codeDomProvider = System.CodeDom.Compiler.CodeDomProvider.CreateProvider("cs"))
             {
                 var compilerParameters = new System.CodeDom.Compiler.CompilerParameters();

--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/jsb.editor.binding.asmdef
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/jsb.editor.binding.asmdef
@@ -6,15 +6,15 @@
         "GUID:595d45be140461240b6b4358dc45f2c0",
         "GUID:ac4126d60783f3d4a98aee6be9a997aa"
     ],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_EDITOR || JSB_RUNTIME_REFLECT_BINDING"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Packages/cc.starlessnight.unity-jsb/Source/Native/JSApi.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Native/JSApi.cs
@@ -89,14 +89,14 @@ namespace QuickJS.Native
         public const int CS_JSB_VERSION = 0xa; // expected dll version
         public static readonly int SO_JSB_VERSION; // actual dll version
 
-#if JSB_NO_BIGNUM || (UNITY_WSA && !UNITY_EDITOR) || JSB_WITH_V8_BACKEND
+#if JSB_NO_BIGNUM || ((UNITY_WSA || UNITY_WEBGL) && !UNITY_EDITOR) || JSB_WITH_V8_BACKEND
         public const bool IsOperatorOverloadingSupported = false;
 #else
         public const bool IsOperatorOverloadingSupported = true;
 #endif
 
 #if (UNITY_IPHONE || UNITY_WEBGL) && !UNITY_EDITOR
-	    const string JSBDLL = "__Internal";
+	    public const string JSBDLL = "__Internal";
 #else
 #if JSB_WITH_V8_BACKEND
         public const string JSBDLL = "v8-bridge";
@@ -772,7 +772,7 @@ namespace QuickJS.Native
 
         public static readonly JSAtom JS_ATOM_Error = JSB_ATOM_Error();
 
-#if JSB_NO_BIGNUM || (UNITY_WSA && !UNITY_EDITOR)
+#if JSB_NO_BIGNUM || ((UNITY_WSA || UNITY_WEBGL) && !UNITY_EDITOR)
         public static void JS_AddIntrinsicOperators(JSContext ctx) {}
         public static readonly JSAtom JS_ATOM_Operators;
         public static readonly JSAtom JS_ATOM_Symbol_operatorSet;

--- a/Packages/cc.starlessnight.unity-jsb/Source/Native/JSApi.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Native/JSApi.cs
@@ -573,6 +573,9 @@ namespace QuickJS.Native
         public static extern int JS_ExecutePendingJob(JSRuntime rt, out JSContext pctx);
 
         [DllImport(JSBDLL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int JS_IsJobPending(JSRuntime rt, out JSContext pctx);
+
+        [DllImport(JSBDLL, CallingConvention = CallingConvention.Cdecl)]
         public static extern int JS_ToBool(JSContext ctx, JSValueConst val);
 
         /// <summary>

--- a/Packages/cc.starlessnight.unity-jsb/Source/ScriptRuntime.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/ScriptRuntime.cs
@@ -398,7 +398,7 @@ namespace QuickJS
             _typeDB.AddType(typeof(Unity.JSBehaviour), JSApi.JS_UNDEFINED);
             _typeDB.AddType(typeof(Unity.JSScriptableObject), JSApi.JS_UNDEFINED);
 #endif
-#if UNITY_EDITOR
+#if !JSB_UNITYLESS && UNITY_EDITOR
             _typeDB.AddType(Values.FindType("QuickJS.Unity.JSEditorWindow"), JSApi.JS_UNDEFINED);
             _typeDB.AddType(Values.FindType("QuickJS.Unity.JSBehaviourInspector"), JSApi.JS_UNDEFINED);
 #endif

--- a/Packages/cc.starlessnight.unity-jsb/Source/ScriptRuntime.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/ScriptRuntime.cs
@@ -882,9 +882,15 @@ namespace QuickJS
             while (true)
             {
                 var err = JSApi.JS_ExecutePendingJob(_rt, out ctx);
+
                 if (err >= 0)
                 {
-                    break;
+                    var hasPending = JSApi.JS_IsJobPending(_rt, out ctx);
+
+                    if (hasPending == 0)
+                    {
+                        break;
+                    }
                 }
 
                 if (err < 0)

--- a/Packages/cc.starlessnight.unity-jsb/Source/Unity/Editor/jsb.editor.unity.asmdef
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Unity/Editor/jsb.editor.unity.asmdef
@@ -7,15 +7,15 @@
         "GUID:ac4126d60783f3d4a98aee6be9a997aa",
         "GUID:595d45be140461240b6b4358dc45f2c0"
     ],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_EDITOR || JSB_RUNTIME_REFLECT_BINDING"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Packages/cc.starlessnight.unity-jsb/Source/Utils/DefaultJsonConverter.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Utils/DefaultJsonConverter.cs
@@ -6,11 +6,10 @@ namespace QuickJS.Utils
     {
         public object Deserialize(string json, Type type)
         {
-#if JSB_UNITYLESS
+            // If inside Unity, use Unity's JSON utility even if JSB_UNITYLESS is defined
+#if JSB_UNITYLESS && !UNITY_2019_1_OR_NEWER
 #if JSB_COMPATIBLE
             throw new NotImplementedException();
-#elif JSB_NEWTONSOFT_JSON
-            return Newtonsoft.Json.JsonConvert.DeserializeObject(json, type);
 #else
             return System.Text.Json.JsonSerializer.Deserialize(json, type);
 #endif
@@ -21,11 +20,9 @@ namespace QuickJS.Utils
 
         public string Serialize(object obj, bool prettyPrint)
         {
-#if JSB_UNITYLESS
+#if JSB_UNITYLESS && !UNITY_2019_1_OR_NEWER
 #if JSB_COMPATIBLE
             throw new NotImplementedException();
-#elif JSB_NEWTONSOFT_JSON
-            return Newtonsoft.Json.JsonConvert.SerializeObject(obj);
 #else
             return System.Text.Json.JsonSerializer.Serialize(obj);
 #endif

--- a/Packages/cc.starlessnight.unity-jsb/Source/Utils/DefaultJsonConverter.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Utils/DefaultJsonConverter.cs
@@ -9,6 +9,8 @@ namespace QuickJS.Utils
 #if JSB_UNITYLESS
 #if JSB_COMPATIBLE
             throw new NotImplementedException();
+#elif JSB_NEWTONSOFT_JSON
+            return Newtonsoft.Json.JsonConvert.DeserializeObject(json, type);
 #else
             return System.Text.Json.JsonSerializer.Deserialize(json, type);
 #endif
@@ -22,6 +24,8 @@ namespace QuickJS.Utils
 #if JSB_UNITYLESS
 #if JSB_COMPATIBLE
             throw new NotImplementedException();
+#elif JSB_NEWTONSOFT_JSON
+            return Newtonsoft.Json.JsonConvert.SerializeObject(obj);
 #else
             return System.Text.Json.JsonSerializer.Serialize(obj);
 #endif

--- a/Packages/cc.starlessnight.unity-jsb/Source/Utils/TypeDB.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Utils/TypeDB.cs
@@ -73,8 +73,8 @@ namespace QuickJS.Utils
 
             var register = _context.CreateTypeRegister();
 
-            // var parentType = type.BaseType != null ? GetDynamicType(type.BaseType, false) : null;
-            dynamicType = new DynamicType(type, privateAccess/*, parentType*/);
+            var parentType = type.BaseType != null ? GetDynamicType(type.BaseType, false) : null;
+            dynamicType = new DynamicType(type, privateAccess, parentType);
             dynamicType.Bind(register);
             _dynamicTypes[type] = dynamicType;
 
@@ -93,8 +93,8 @@ namespace QuickJS.Utils
                 return dynamicType;
             }
 
-            // var parentType = type.BaseType != null ? GetDynamicType(type.BaseType, false) : null;
-            dynamicType = new DynamicType(type, false/*, parentType*/);
+            var parentType = type.BaseType != null ? GetDynamicType(type.BaseType, false) : null;
+            dynamicType = new DynamicType(type, false, parentType);
             _dynamicTypes[type] = dynamicType;
             return dynamicType;
         }


### PR DESCRIPTION
Summary of changes:

1 - WSA and WebGL native binaries were causing issue in build. Had to change their meta.
2 - Some fixes when `JSB_UNITYLESS` is defined even when we are inside `UNITY_EDITOR`
3 - Codegen & NetStandard issues (Probably we should unify define variables which are used across the project. `NET_STANDARD_2_0` is correct but there is also `NET_STANDARD_2_1` and `NET_STANDARD`, but they may not be available in all Unity versions)
4 - ~Added `JSB_NEWTONSOFT_JSON` flag. When using `JSB_UNITYLESS` inside Unity, `System.Text.Json` namespace isn't available by default. This is not a nice solution, so I am open to suggestions.~ Edit: Modified code to use Unity's own serializer if inside Unity, even if `JSB_UNITYLESS` is defined.
5 - Enabled back DynamicType prototype inheritance. This time without GC leaks.
6 - Improved `ExecutePendingJob` to check if there are pending jobs remaining. This is a weird one, because you would expect QuickJS to do this automatically. But some cases did not work. For example:

```
console.log('Executed');

Promise.resolve().then(() => {
  console.log('PostPromise Depth 1');

  Promise.resolve().then(() => {
    console.log('PostPromise Depth 2');

    Promise.resolve().then(() => {
      console.log('PostPromise Depth 3');

      Promise.resolve().then(() => {
        console.log('PostPromise Depth 4');
      });

      console.log('P4');
    });

    console.log('P3');
  });

  console.log('P2');
});
```

When this code executes, it shows the following in browser:

![image](https://user-images.githubusercontent.com/6034931/169704155-f5426403-a238-4e8c-a9e9-763b6d9a0a3b.png)

But in unity-jsb, it shows only up to "P3". It shows the rest in the next updates.