### PR TITLE
Dictionary conversion with proxy and other conversion improvements

### DIFF
--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/BindingCallback/ReflectBindingCallback.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/BindingCallback/ReflectBindingCallback.cs
@@ -195,11 +195,7 @@ namespace QuickJS.Binding
 
             if (!CodeGenUtils.IsCodeEmitSupported())
             {
-#if JSB_UNITYLESS
-                Console.WriteLine("[Warning] " + CodeGenUtils.CodeEmitWarning);
-#else
-                UnityEngine.Debug.LogWarning(CodeGenUtils.CodeEmitWarning);
-#endif
+                runtime.GetLogger().Write(Utils.LogLevel.Warn, CodeGenUtils.CodeEmitWarning);
             }
         }
 

--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/Values.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/Values.cs
@@ -9,6 +9,7 @@ namespace QuickJS.Binding
     public partial class Values
     {
         public const string KeyForCSharpTypeID = "__csharp_type_id__";
+        public const string KeyForCSharpIdentity = "__csharp_host_identity__";
         public const string NamespaceOfStaticBinder = "QuickJS";
         public const string ClassNameOfStaticBinder = "StaticBinder";
         public const string MethodNameOfStaticBinder = "BindAll";

--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/Values_get.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/Values_get.cs
@@ -1249,7 +1249,26 @@ namespace QuickJS.Binding
                 return true;
             }
 
+            bool valueDuplicated = false;
+
+            if (val.IsObject())
+            {
+                var identityAtom = ScriptEngine.GetContext(ctx).GetAtom(KeyForCSharpIdentity);
+                var identity = JSApi.JS_GetProperty(ctx, val, identityAtom);
+                if (!identity.IsNullish())
+                {
+                    val = identity;
+                    valueDuplicated = true;
+                }
+            }
+
             var header = JSApi.jsb_get_payload_header(ctx, val);
+
+            if (valueDuplicated)
+            {
+                JSApi.JS_FreeValue(ctx, val);
+            }
+
             switch (header.type_id)
             {
                 case BridgeObjectType.ObjectRef:

--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/Values_new.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/Values_new.cs
@@ -161,11 +161,11 @@ createDictionaryProxy;
             var keys = new Func<IDictionary<string, object>, object>(
                 (IDictionary<string, object> dc) =>
                 {
-                    var keys = dc.Keys;
-                    var len = keys.Count;
+                    var items = dc.Keys;
+                    var len = items.Count;
                     var arr = new string[len];
                     var i = 0;
-                    foreach (var item in keys)
+                    foreach (var item in items)
                         arr[i++] = item;
                     return arr;
                 });

--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/Values_new.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/Values_new.cs
@@ -68,6 +68,12 @@ namespace QuickJS.Binding
 
             var object_id = cache.AddObject(o, false);
             var val = JSApi.jsb_new_bridge_object(ctx, proto, object_id);
+
+            if (typeof(IDictionary<string, object>).IsAssignableFrom(type))
+            {
+                val = CreateDictionaryProxy(context, val);
+            }
+
             if (val.IsException())
             {
                 cache.RemoveObject(object_id);
@@ -81,6 +87,91 @@ namespace QuickJS.Binding
             }
 
             return val;
+        }
+
+        private static unsafe JSValue CreateDictionaryProxy(ScriptContext _context, JSValue target)
+        {
+            var ctx = (JSContext)_context;
+
+            var createDictionaryProxy = _context.EvalSource<ScriptFunction>(@"
+function createDictionaryProxy (targetProxy, contains, getter, setter, keys) {
+    return new Proxy(targetProxy, {
+        get(target, key, receiver) {
+            if(key === '" + KeyForCSharpIdentity + @"') return target;
+
+            if(typeof key === 'string' && contains(target, key)) return getter(target, key);
+            var res = target[key];
+            return res;
+        },        
+        set(target, key, value) {
+            if(typeof key === 'string') setter(target, key, value);
+            else target[key] = value;
+            return true;
+        },
+        ownKeys(target) {
+            return keys(target);
+        },
+        getOwnPropertyDescriptor(target, key) {
+            if(typeof key === 'string' && contains(target, key)) {
+                return {
+                  value: getter(target, key),
+                  enumerable: true,
+                  configurable: true
+                };
+            }
+            return undefined;
+        }
+    });
+}
+
+createDictionaryProxy;
+", "createDictionaryProxy");
+
+            var contains = new Func<IDictionary<string, object>, string, bool>(
+                (IDictionary<string, object> dc, string key) =>
+                {
+                    return key != null && dc.ContainsKey(key);
+                });
+
+            var getter = new Func<IDictionary<string, object>, string, object>(
+                (IDictionary<string, object> dc, string key) =>
+                {
+                    return dc[key];
+                });
+
+            var setter = new Action<IDictionary<string, object>, string, object>(
+                (IDictionary<string, object> dc, string key, object value) =>
+                {
+                    dc[key] = value;
+                });
+
+            var keys = new Func<IDictionary<string, object>, object>(
+                (IDictionary<string, object> dc) =>
+                {
+                    var keys = dc.Keys;
+                    var len = keys.Count;
+                    var arr = new string[len];
+                    var i = 0;
+                    foreach (var item in keys)
+                        arr[i++] = item;
+                    return arr;
+                });
+
+            var prs = new object[] {
+                target,
+                contains,
+                getter,
+                setter,
+                keys,
+            };
+
+            var _proxy = createDictionaryProxy.Invoke<ScriptValue>(prs);
+
+            var res = JSApi.JS_DupValue(ctx, _proxy);
+            _proxy.Dispose();
+            createDictionaryProxy.Dispose();
+            JSApi.JS_FreeValue(ctx, target);
+            return res;
         }
     }
 }


### PR DESCRIPTION
Added a special conversion for all types deriving from `IDictionary<string,object>`, so that they can be treated as regular JS objects. There seemed to be no way to do this from outside, so I had to add it into source code. I had to improvise a bit at the part with the object identity. Because when proxy is passed back to C#, we want to get original dictionary.

Note that this is not tested for static codegen. It is also somewhat opinionated. Expecting your feedback.

Also added another conversion trick when converting to `object`. This was needed because structs don't get cached, so the `js_get_cached_object` does not return a value for them. But they also have a original C# object that can be converted to `object`.