### PR TITLE
Improve method calls with optional arguments

### DIFF
--- a/Assets/Examples/Source/Experimental/CustomApiBridgeImpl.cs
+++ b/Assets/Examples/Source/Experimental/CustomApiBridgeImpl.cs
@@ -53,10 +53,11 @@ namespace Example.Experimental
                     var proxy = CreateDictionaryProxy(context, val);
                     if (proxy.IsException())
                     {
-                        JSApi.JS_FreeValue(context, val);
+                        JSApi.JS_FreeValue(context, proxy);
                         cache.RemoveObject(object_id);
                         return proxy;
                     }
+                    val = proxy;
                 }
                 cache.AddJSValue(o, val);
             }

--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/Values_match.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/Values_match.cs
@@ -250,6 +250,16 @@ namespace QuickJS.Binding
             {
                 var parameterInfo = parameterInfos[i];
                 var pType = parameterInfo.ParameterType;
+
+                if (i >= argv.Length)
+                {
+                    if (!parameterInfo.IsOptional)
+                    {
+                        return false;
+                    }
+                    continue;
+                }
+
                 if (pType.IsByRef)
                 {
                     if (!js_match_type_hint(ctx, argv[i], pType.GetElementType()))


### PR DESCRIPTION
Some methods and constructors were not callable if exact number of arguments were not given, even if they have default value for those arguments.

Also fixed a crash in the experimental dictionary bridge.