### PR TITLE
Increase function magic numbers from 16-bit to 32-bit

### DIFF
--- a/jsb_build/quickjs/quickjs-latest/quickjs.c
+++ b/jsb_build/quickjs/quickjs-latest/quickjs.c
@@ -923,7 +923,7 @@ struct JSObject {
             JSCFunctionType c_function;
             uint8_t length;
             uint8_t cproto;
-            int16_t magic;
+            int32_t magic;
         } cfunc;
         /* array part for fast arrays and typed arrays */
         struct { /* JS_CLASS_ARRAY, JS_CLASS_ARGUMENTS, JS_CLASS_UINT8C_ARRAY..JS_CLASS_FLOAT64_ARRAY */

--- a/jsb_build/quickjs/quickjs-wsa/quickjs.c
+++ b/jsb_build/quickjs/quickjs-wsa/quickjs.c
@@ -925,7 +925,7 @@ struct JSObject {
             JSCFunctionType c_function;
             uint8_t length;
             uint8_t cproto;
-            int16_t magic;
+            int32_t magic;
         } cfunc;
         /* array part for fast arrays and typed arrays */
         struct { /* JS_CLASS_ARRAY, JS_CLASS_ARGUMENTS, JS_CLASS_UINT8C_ARRAY..JS_CLASS_FLOAT64_ARRAY */


### PR DESCRIPTION
When I do too much calls to dynamic methods, after a while I receive an error like "dynamic method not found". It happens after 32767 calls because magic number goes negative after that. This seems too low and I think QuickJS should support 32 bit magic numbers. The dynamic method list in C# side is written for 32 bit integer.