### PR TITLE
[WebGL backend] Make WebSocket and XHR scoped to context, add base url support

### DIFF
--- a/Packages/cc.starlessnight.unity-jsb/Plugins/WebGL/.source/typings/jsapi.d.ts
+++ b/Packages/cc.starlessnight.unity-jsb/Plugins/WebGL/.source/typings/jsapi.d.ts
@@ -170,6 +170,8 @@ declare global {
     static jsb_set_int_4(ctx: JSContext, val: JSValue, v0: number, v1: number, v2: number, v3: number): Boolish;
     static jsb_set_byte_4(ctx: JSContext, val: JSValue, v0: Byte, v1: Byte, v2: Byte, v3: Byte): Boolish;
     static jsb_set_bytes(ctx: JSContext, val: JSValue, n: number, v0: Pointer<Byte>): Boolish;
+
+    static JS_SetBaseUrl(ctx: JSContext, url: Pointer<string>): void;
   }
 
   export declare class JSApiDelegates {

--- a/Packages/cc.starlessnight.unity-jsb/Plugins/WebGL/.source/typings/plugin.d.ts
+++ b/Packages/cc.starlessnight.unity-jsb/Plugins/WebGL/.source/typings/plugin.d.ts
@@ -4,7 +4,7 @@ declare global {
   var unityJsbState: PluginState;
 
   export declare type PluginState = {
-    stringify: ((ptr: number | Pointer<number>, bufferLength?: number) => string);
+    stringify: ((ptr: number | Pointer<string>, bufferLength?: number) => string);
     bufferify: ((str: string) => [number, number]);
     dynCall: typeof dynCall;
     runtimes: Record<string, PluginRuntime | undefined>;
@@ -37,11 +37,17 @@ declare global {
     runtimeId: number;
 
     window: Window;
+    iframe: HTMLIFrameElement;
+    contentWindow: Window;
+
     globalObject: Window;
     globalObjectId?: number;
 
     evaluate: ((script: string, filename?: string) => any);
     lastException?: Error;
+
+    free(): void;
+    setBaseUrl(url: string): void;
   };
 
   export declare type AtomReferences = {


### PR DESCRIPTION
This PR makes XHR, fetch and WebSocket requests created in WebGL backend scoped to the context they were created in. So that when context is disposed, the request is disposed as well. Also added base url support. With this, relative URLs will be resolved relative to that base url. One use case for this is providing the dev server URL when you are running Webpack, so that users get hot reloading. 