### PR TITLE
Added priority to binding process to control order

### DIFF
--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/AbstractBindingProcess.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/AbstractBindingProcess.cs
@@ -59,5 +59,7 @@ namespace QuickJS.Binding
         public virtual void OnCleanup(BindingManager bindingManager)
         {
         }
+        
+        public virtual int Priority { get; set; }
     }
 }

--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/BindingManager.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/BindingManager.cs
@@ -359,6 +359,7 @@ namespace QuickJS.Binding
 
                             inst.OnInitialize(this);
                             _enabledBindingProcess.Add(inst);
+                            _enabledBindingProcess.Sort((p1, p2) => p1.Priority.CompareTo(p2.Priority));
                             _bindingLogger?.Log($"add binding process: {type}");
                         }
                     }

--- a/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/IBindingProcess.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/Binding/Editor/IBindingProcess.cs
@@ -44,5 +44,7 @@ namespace QuickJS.Binding
         
         // 完成默认清理行为后 
         void OnCleanup(BindingManager bindingManager);
+        
+        int Priority { get; set; }
     }
 }


### PR DESCRIPTION
I found this useful to control whether my `CustomBinding` was run after the UnityBindings. Without this, I believe the order is non-deterministic.