### PR TITLE
WebGL microtask fix

### DIFF
--- a/Packages/cc.starlessnight.unity-jsb/Plugins/WebGL/.source/typings/plugin.d.ts
+++ b/Packages/cc.starlessnight.unity-jsb/Plugins/WebGL/.source/typings/plugin.d.ts
@@ -27,6 +27,7 @@ declare global {
     opaque?: any;
     contexts: Record<string, PluginContext | undefined>;
     refs: ObjectReferences;
+    isDestroyed: boolean;
     garbageCollect(): number;
   };
 
@@ -35,6 +36,7 @@ declare global {
     opaque?: any;
     runtime: PluginRuntime;
     runtimeId: number;
+    isDestroyed: boolean;
 
     window: Window;
     iframe: HTMLIFrameElement;

--- a/Packages/cc.starlessnight.unity-jsb/Source/ScriptContext.cs
+++ b/Packages/cc.starlessnight.unity-jsb/Source/ScriptContext.cs
@@ -850,6 +850,7 @@ namespace QuickJS
             if (JSApi.JS_IsException(jsValue))
             {
                 var ex = _ctx.GetExceptionString();
+                JSApi.JS_FreeValue(_ctx, jsValue);
                 throw new JSException(ex, fileName);
             }
             object retObject;


### PR DESCRIPTION
There was a specific case where code would try to run after context is destroyed. This happened when a code was inside `Promise.then`. This does not happen with `setTimeout` and similar because `iframe` is unmounted when a context is destroyed, so the JavaScript engine should not be running anymore. But it was happening in Promise for some reason.

Also fixed a small memory leak when code throws error in eval.